### PR TITLE
(feat) extension: adds load more link if there are > 25 replies to a comment.

### DIFF
--- a/extension/chrome/lib/css/sideframe.css
+++ b/extension/chrome/lib/css/sideframe.css
@@ -463,12 +463,12 @@ h4.comment-username,
     background-color: #f6f7f8;
 }
 
-.comment-reply {
+.comment-reply, .comment-reply-more {
     margin:0px;
     padding:5px;
      background-color: #f6f7f8;
 }
-.comment-reply {
+.comment-reply, .comment-reply-more {
     font-size: 0.8em;
 }
 .comment-reply .media-body {

--- a/extension/chrome/sideframe.html
+++ b/extension/chrome/sideframe.html
@@ -183,6 +183,12 @@
                         </div>
                     </div>
                 </div>
+                <div class="reply-container"></div>
+                <div class="col-xs-12 comment-reply-more row hidden">
+                    <div class="comment-wrapper row media media-left">
+                        <a href="#" class="replies-more">Load more replies...</a>
+                    </div>
+                </div>
                 {{/unless}}
             </div>
         </div>

--- a/extension/chrome/sideframe.html
+++ b/extension/chrome/sideframe.html
@@ -183,7 +183,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="reply-container"></div>
+                <div class="reply-container hidden"></div>
                 <div class="col-xs-12 comment-reply-more row hidden">
                     <div class="comment-wrapper row media media-left">
                         <a href="#" class="replies-more">Load more replies...</a>

--- a/extension/chrome/sideframe.js
+++ b/extension/chrome/sideframe.js
@@ -600,7 +600,14 @@ function registerCommentEventListeners(comment) {
       var repliesToId = $($(this)[0]).attr('data-comment-id');
       var replies = comment.find('.comment-reply');
       var target = comment.find('.reply-container');
-      target.toggleClass('hidden');
+      var loadMore = comment.find('.comment-reply-more');
+
+      if (target.hasClass('hidden')) {
+        target.removeClass('hidden');
+      } else {
+        target.addClass('hidden');
+        loadMore.addClass('hidden');
+      }
 
       // if the target class is moved to be not hidden
       // on this toggle, try loading more comments

--- a/extension/chrome/sideframe.js
+++ b/extension/chrome/sideframe.js
@@ -418,6 +418,7 @@ function loadMoreComments(destination, url, repliesToId) {
 
   if (repliesToId && tracking[repliesToId]){
     if (tracking[repliesToId].endOfComments || !tracking.requestReturned) {
+      console.log('loadMoreComments: skipping loading.');
       return;
     }
   }
@@ -582,11 +583,21 @@ function registerCommentEventListeners(comment) {
   for (var i = 0; i < showReplies.length; i++) {
     
     $(showReplies[i]).off('click').on('click', function() {
-      var target = $(this).parents('.comment');
+      var comment = $(this).parents('.comment');
       var repliesToId = $($(this)[0]).attr('data-comment-id');
+      var replies = comment.find('.comment-reply');
 
-      var thisComment = $(this).parents('.comment');
-      var replies = thisComment.find('.comment-reply');
+      // Currently just always showing the load more link
+      // if the showReplies button is clicked.
+      // TODO: 
+      // - only show 'load more' if there are > 0 replies
+      // - only show 'load more' if there are more replies to load
+      var loadMore = comment.find('.comment-reply-more');
+      loadMore.toggleClass('hidden');
+      console.log('showReplies: loadMore elt is ', loadMore);
+
+      var target = comment.find('.reply-container');
+      console.log('showReplies: target elt is ', target);
 
       // toggle whether
       if (replies.length > 0) {
@@ -599,6 +610,24 @@ function registerCommentEventListeners(comment) {
       } else {
         loadMoreComments(target, url, repliesToId);
       }
+    });
+  }
+
+  // Listen on clicks to request loading additional replies.
+  var repliesMore = document.getElementsByClassName('replies-more');
+  console.log('Setting event listeners, repliesMore: ', repliesMore);
+
+  for (var i = 0; i < repliesMore.length; i++) {
+    $(repliesMore[i]).off('click').on('click', function() {
+      var comment = $(this).parents('.comment');
+      var repliesToId = comment.attr('id');
+      console.log('repliesMore: parent comment ', comment);
+      console.log('id: ', repliesToId);
+
+      var target = comment.find('.reply-container');
+      console.log('repliesMore: target elt is ', target);
+
+      loadMoreComments(target, url, repliesToId);
     });
   }
 

--- a/extension/chrome/sideframe.js
+++ b/extension/chrome/sideframe.js
@@ -491,14 +491,27 @@ function loadMoreComments(destination, url, repliesToId) {
         tracking.commentOffset += msg.comments.length;
       }
     } else {
+      console.log('loadMoreComments: success loading ' + msg.comments.length + ' replies.');
       if (msg.comments.length > 0) {
         tracking[repliesToId].id = msg.comments[msg.comments.length - 1].id;
       }
       // Same logic regarding comment loads, but for the reply tracking.
+      // Also, if we haven't loaded all the replies yet, show
+      // the link to load additional replies.
+      // Assumes that the reply container is currently visible.
+      //  - true for case coming from 'show reply' click, b/c
+      //    loadMoreComments only called if reply container !hidden
+      //  - true for case coming from 'show more replies' if the
+      //    above holds true, b/c this link only avail if container !hidden
+      var comment = destination.parents('.comment');
+      var loadMore = comment.find('.comment-reply-more');
+
       if (msg.comments.length < 25) {
         tracking[repliesToId].endOfComments = true;
+        loadMore.addClass('hidden');
       } else {
         tracking[repliesToId].endOfComments = false;
+        loadMore.removeClass('hidden');
       }
     }
 
@@ -586,28 +599,12 @@ function registerCommentEventListeners(comment) {
       var comment = $(this).parents('.comment');
       var repliesToId = $($(this)[0]).attr('data-comment-id');
       var replies = comment.find('.comment-reply');
-
-      // Currently just always showing the load more link
-      // if the showReplies button is clicked.
-      // TODO: 
-      // - only show 'load more' if there are > 0 replies
-      // - only show 'load more' if there are more replies to load
-      var loadMore = comment.find('.comment-reply-more');
-      loadMore.toggleClass('hidden');
-      console.log('showReplies: loadMore elt is ', loadMore);
-
       var target = comment.find('.reply-container');
-      console.log('showReplies: target elt is ', target);
+      target.toggleClass('hidden');
 
-      // toggle whether
-      if (replies.length > 0) {
-        if (!$(replies[0]).hasClass('hidden')) {
-          $(replies).addClass('hidden');
-        } else {
-          $(replies).removeClass('hidden');
-          loadMoreComments(target, url, repliesToId);
-        }
-      } else {
+      // if the target class is moved to be not hidden
+      // on this toggle, try loading more comments
+      if (!target.hasClass('hidden')) {
         loadMoreComments(target, url, repliesToId);
       }
     });
@@ -615,7 +612,7 @@ function registerCommentEventListeners(comment) {
 
   // Listen on clicks to request loading additional replies.
   var repliesMore = document.getElementsByClassName('replies-more');
-  console.log('Setting event listeners, repliesMore: ', repliesMore);
+  // console.log('Setting event listeners, repliesMore: ', repliesMore);
 
   for (var i = 0; i < repliesMore.length; i++) {
     $(repliesMore[i]).off('click').on('click', function() {


### PR DESCRIPTION
- Note: toggling 'show replies' off and on again results in loading more replies again, so will eliminate need for 'load more' link if there are < 25 more replies.