### PR TITLE
(bug) extension: fixes loading additional comments if sorting by replies or favorites.

### DIFF
--- a/server/components/comment/getComments.js
+++ b/server/components/comment/getComments.js
@@ -127,6 +127,8 @@ module.exports = function(sequelize, options) {
   
   queryString += ';';
 
+  // console.log('getComments: ', queryString);
+
   return sequelize.query(queryString);
 };
 

--- a/server/components/user/getUserInfo.js
+++ b/server/components/user/getUserInfo.js
@@ -2,6 +2,6 @@ module.exports = function(sequelize, id) {
   var queryString = 'SELECT id AS userId, name AS username, avatar AS userAvatar, repliesToCheck, heartsToCheck,' +
       '(SELECT COUNT(1) AS other FROM Comments WHERE Comments.UserId =' + id + ') AS numComments ' +
     'FROM Users WHERE id=' + id + ';';
-    console.log(queryString);
+    // console.log(queryString);
   return sequelize.query(queryString);
 };


### PR DESCRIPTION
- loadMoreComments: lastCommentId was incorrectly getting set in query if sorting by replies or favorites.
- When sorting by replies, the commentOffset tracking field was not getting properly updated, and passed to the query in loadMoreComments.